### PR TITLE
remove duplicate weather_windy_variant icon

### DIFF
--- a/packages/pixel_clock.yaml
+++ b/packages/pixel_clock.yaml
@@ -441,8 +441,6 @@ ehmtxv2:
       lameid: 2282
     - id: weather_windy
       lameid: 21909
-    - id: weather_windy_variant
-      lameid: 21909
     - id: weather_cloudy_night
       lameid: 12195
 


### PR DESCRIPTION
INFO  ICONS: Load 21909 from cache.
INFO animation weather_windy with 8 frame(s)
INFO  ICONS: Load 21909 from cache.
INFO animation weather_windy_variant with 8 frame(s)

Both are 21909